### PR TITLE
fixing doc for stream param in exec_run

### DIFF
--- a/docker/models/containers.py
+++ b/docker/models/containers.py
@@ -181,7 +181,8 @@ class Container(Model):
             user (str): User to execute command as. Default: root
             detach (bool): If true, detach from the exec command.
                 Default: False
-            stream (bool): Stream response data. Default: False
+            stream (bool): Stream response data. Ignored if ``detach`` is true.
+                Default: False
             socket (bool): Return the connection socket to allow custom
                 read/write operations. Default: False
             environment (dict or list): A dictionary or a list of strings in


### PR DESCRIPTION
Looks like this doc update was missed.

When you run the code below, you get `<class 'str'>`. If you change detach to `False`, you get `<class 'docker.types.daemon.CancellableStream'>`. This means stream param is getting ignored and should be explicitly documented just like it is for the `run` command.

```python
import docker
from dotenv import load_dotenv

load_dotenv()

client = docker.from_env()

container = client.containers.run(
    "python:3",
    command="/bin/bash",
    stdin_open=True,
    tty=True,
    detach=True,
    working_dir="/usr/src"
)

exit_code, output = container.exec_run(
    "ls -la /",
    stdout=True,
    stderr=True,
    tty=True,
    stream=True,
    detach=True,
)

print(type(output))
```